### PR TITLE
[frio] Fix terms capitalization

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -1252,7 +1252,7 @@ function status_editor($a,$x, $notes_cid = 0, $popup=false) {
 		'$placeholdercategory' => (feature_enabled(local_user(),'categories') ? t('Categories (comma-separated list)') : ''),
 		'$wait' => t('Please wait'),
 		'$permset' => t('Permission settings'),
-		'$shortpermset' => t('permissions'),
+		'$shortpermset' => t('Permissions'),
 		'$ptyp' => (($notes_cid) ? 'note' : 'wall'),
 		'$content' => $x['content'],
 		'$post_id' => $x['post_id'],

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -794,7 +794,8 @@ nav.navbar a {
     color: $nav_icon_color;
     font-weight: 400;
     font-size: 13px;
-    padding: 4px 15px
+    padding: 4px 15px;
+    text-transform: capitalize;
 }
 .nav-pills .dropdown-menu li a i,
 .nav-tabs .dropdown-menu li a i,

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1498,6 +1498,7 @@ blockquote.shared_content {
 .wall-item-actions .button-likes {
     padding-left: 0px;
     padding-right: 0px;
+	text-transform: capitalize;
 }
 
 /* wall item hover effects */

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -3,7 +3,7 @@ To change this license header, choose License Headers in Project Properties.
 To change this template file, choose Tools | Templates
 and open the template in the editor.
 */
-/* 
+/*
     Created on : 17.02.2016, 23:55:45
     Author     : rabuzarus
 */
@@ -174,7 +174,7 @@ a#item-delete-selected {
     background: $btn_primary_hover_color;
     border-color: none;
 }
-	
+
 .btn-link {
 /*    color: #6fdbe8;*/
     color: $link_color;
@@ -287,7 +287,7 @@ header #banner {
     whitespace: nowrap;
     padding-left: 55px;
 }
-header #banner #logo-img, 
+header #banner #logo-img,
 .navbar-brand #logo-img {
     /*mask: url('network#m1');*/
     /*mask-image: url('img/friendica-25.png');*/
@@ -419,7 +419,7 @@ nav.navbar .nav>li>a:focus{
     top: 4px;
     right: -2px;
     background-color: #ff8989;
-    
+
 /*    text-transform: uppercase;
     display: inline-block;
     padding: 3px 5px 4px;
@@ -1093,7 +1093,7 @@ aside #group-sidebar li .group-edit-tool:first-child {
     width: 90px;*/
 }
 #contact-block contact-block-link {
-    
+
 }
 #contact-block .contact-block-img {
     height: 75px;
@@ -1648,7 +1648,7 @@ img.acpopup-img {
 .wall-item-container.thread_level_6,
 .wall-item-container.thread_level_7 {
   margin-left: 15px;
-  
+
 }
 /* Menubar Tabs */
 #tabmenu,
@@ -1681,7 +1681,7 @@ ul.tabs li {
     transition: all .15s ease;
 }
 /*ul.tabs.visible-xs > li.active {
-    min-width: 150px;  This is a workaround to make the topbar-second dropdown better visible on mobile. We need something better here 
+    min-width: 150px;  This is a workaround to make the topbar-second dropdown better visible on mobile. We need something better here
 }*/
 ul.tabs li a {
     margin-left: 10px;
@@ -1895,7 +1895,7 @@ ul.viewcontact_wrapper > li {
 }
 .contact-wrapper .contact-photo-image-wrapper img.contact-photo.xl {
     height: 80px;
-    width: 80px;    
+    width: 80px;
 }
 .contact-wrapper .contact-photo-image-wrapper img.contact-photo-xs {
     height: 48px;
@@ -1912,7 +1912,7 @@ ul.viewcontact_wrapper > li {
     margin-top: -20px;
 }
 .contact-wrapper .media-body .contact-entry-name h4.media-heading a {
-    font-weight: bold !important; 
+    font-weight: bold !important;
     color: $link_color;
     font-size: 15px !important;
 }
@@ -2272,7 +2272,7 @@ ul.notif-network-list > li:hover .intro-action-buttons {
 
 /* Search Page */
 
-/* This is a little bit hacky. Since the search page is used for diferent 
+/* This is a little bit hacky. Since the search page is used for diferent
 content types we can't apply the generic-page-wrapper class.
 So we apply the css of the generic-page-wrapper class to the ul element with some
 little modifications to emulate a standard page template */
@@ -2381,7 +2381,7 @@ main .nav-tabs>li.active>a:hover {
 #contact-list ul.dropdown-menu.textcomplete-dropdown.media-list > li:first-child {
     display: none;
 }
-#contact-list ul.dropdown-menu.textcomplete-dropdown.media-list 
+#contact-list ul.dropdown-menu.textcomplete-dropdown.media-list
 .textcomplete-item > a {
     padding: 0 !important;
     border-left: none;


### PR DESCRIPTION
There are many translation terms that are inconsistently lowercase. This results in menus where lowercase and capitalized link are mixed.

Rather than change the translation terms that people have already worked on to translate, I'm taking a CSS-based approach to normalize links and titles.
