### PR TITLE
Like fix improvements

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -1889,9 +1889,33 @@ function goaway($s) {
  * @return int|bool user id or false
  */
 function local_user() {
-	if((x($_SESSION,'authenticated')) && (x($_SESSION,'uid')))
+	if (x($_SESSION, 'authenticated') && x($_SESSION, 'uid')) {
 		return intval($_SESSION['uid']);
+	}
 	return false;
+}
+
+/**
+ * @brief Returns the public contact id of logged in user or false.
+ *
+ * @return int|bool public contact id or false
+ */
+function public_contact() {
+	static $public_contact_id = false;
+
+	if (!$public_contact_id && x($_SESSION, 'authenticated')) {
+		if (x($_SESSION, 'my_address')) {
+			// Local user
+			$public_contact_id = intval(get_contact($_SESSION['my_address'], 0));
+		} else if (x($_SESSION, 'visitor_home')) {
+			// Remote user
+			$public_contact_id = intval(get_contact($_SESSION['visitor_home'], 0));
+		}
+	} else if (!x($_SESSION, 'authenticated')) {
+		$public_contact_id = false;
+	}
+
+	return $public_contact_id;
 }
 
 /**

--- a/include/conversation.php
+++ b/include/conversation.php
@@ -416,8 +416,8 @@ These Fields are not added below (yet). They are here to for bug search.
 `item`.`shadow`,
 */
 
-	return "`item`.`author-link`, `item`.`author-name`, `item`.`author-avatar`,
-		`item`.`owner-link`, `item`.`owner-name`, `item`.`owner-avatar`,
+	return "`item`.`author-id`, `item`.`author-link`, `item`.`author-name`, `item`.`author-avatar`,
+		`item`.`owner-id`, `item`.`owner-link`, `item`.`owner-name`, `item`.`owner-avatar`,
 		`item`.`contact-id`, `item`.`uid`, `item`.`id`, `item`.`parent`,
 		`item`.`uri`, `item`.`thr-parent`, `item`.`parent-uri`,
 		`item`.`commented`, `item`.`created`, `item`.`edited`,
@@ -1066,8 +1066,9 @@ function builtin_activity_puller($item, &$conv_responses) {
 			else
 				$conv_responses[$mode][$item['thr-parent']] ++;
 
-			if((local_user()) && (local_user() == $item['uid']) && ($item['self']))
+			if (public_contact() == $item['author-id']) {
 				$conv_responses[$mode][$item['thr-parent'] . '-self'] = 1;
+			}
 
 			$conv_responses[$mode][$item['thr-parent'] . '-l'][] = $url;
 


### PR DESCRIPTION
Re-Fixes #2792

This PR is two-pronged:
- It makes sure that the like display is accurate by using `author-id` instead of the unreliable `contact-id`
- It prevents `do_like()` from deleting other people's likes due to `contact-id` unreliability

As an extra, it's no longer required to click twice on the event attendance buttons to switch state.